### PR TITLE
feature - start all service via docker compose

### DIFF
--- a/infra/docker/docker-compose.override.yaml
+++ b/infra/docker/docker-compose.override.yaml
@@ -10,6 +10,8 @@ services:
   kong:
     env_file:
       - ../supabase/.env
+    networks:
+      - pilot-space-network
 
   auth:
     env_file:
@@ -54,6 +56,8 @@ services:
   redis:
     env_file:
       - ../supabase/.env
+    networks:
+      - pilot-space-network
 
   meilisearch:
     env_file:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       REDIS_MAX_CONNECTIONS: ${REDIS_MAX_CONNECTIONS:-10}
 
       # Supabase (when using external Supabase)
-      SUPABASE_URL: ${SUPABASE_URL:-http://localhost:54321}
+      SUPABASE_URL: ${SUPABASE_URL:-http://kong:8000}
       SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
       # SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY:-}
       SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}

--- a/infra/supabase/.env.example
+++ b/infra/supabase/.env.example
@@ -76,12 +76,12 @@ JWT_EXPIRY=3600
 # API GATEWAY (KONG)
 # =============================================================================
 
-KONG_HTTP_PORT=8000
+KONG_HTTP_PORT=8080
 KONG_HTTPS_PORT=8443
 
 # External API URL - How clients access the API
 # For production, use your domain: https://api.your-domain.com
-API_EXTERNAL_URL=http://localhost:8000
+API_EXTERNAL_URL=http://localhost:8080
 
 # =============================================================================
 # SITE CONFIGURATION

--- a/infra/supabase/volumes/db/init/01-extensions.sql
+++ b/infra/supabase/volumes/db/init/01-extensions.sql
@@ -122,7 +122,7 @@ CREATE EXTENSION IF NOT EXISTS "vector";
 CREATE EXTENSION IF NOT EXISTS "pgmq";
 
 -- pg_cron for scheduled jobs (background tasks, cleanup, etc.)
-CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS "pg_cron" WITH SCHEMA extensions;
 
 -- =============================================================================
 -- SEARCH/TEXT EXTENSIONS


### PR DESCRIPTION
This pull request mainly contains improvements and fixes to the database migration scripts, focusing on consistency, code clarity, and proper enum creation in Alembic migrations. The changes include renaming a migration file for clarity, updating references to match the new name, and refactoring how enums are created in several migrations to use SQLAlchemy's `create_type=True` parameter instead of raw SQL. Additionally, some minor formatting and code style improvements were made for better readability.

**Migration file renaming and reference updates:**

- Renamed the migration file `036_fix_ai_sessions_rls_enum_case.py` to `036_fix_ai_sessions_rls_enum.py` and updated all references and revision IDs in subsequent migration files to use the new name for consistency. [[1]](diffhunk://#diff-7f5084b797ed6a8d1d069525c80b5d1eb13284ad6fa1891fc639401c3caed26aL8-R16) [[2]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L8-R8) [[3]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L19-R19)

**Migration code refactoring and consistency:**

- Refactored the creation of Postgres enums in `039_add_skill_executions.py` and `040_add_memory_engine.py` to use SQLAlchemy's `create_type=True` in `sa.Enum` columns, removing redundant raw SQL enum creation. This ensures enums are created only if needed and avoids duplication. [[1]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L30-R30) [[2]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L74-R55) [[3]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L86-R67) [[4]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L25-R25) [[5]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L69-R51) [[6]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L200-R182)

- Updated and improved multi-line SQL execution in several migrations by switching from triple-quoted strings in `op.execute("""...""")` to the more robust `op.execute(<string>)` style, and added closing parentheses for clarity. [[1]](diffhunk://#diff-7f5084b797ed6a8d1d069525c80b5d1eb13284ad6fa1891fc639401c3caed26aL28-R29) [[2]](diffhunk://#diff-7f5084b797ed6a8d1d069525c80b5d1eb13284ad6fa1891fc639401c3caed26aL41-R51) [[3]](diffhunk://#diff-7f5084b797ed6a8d1d069525c80b5d1eb13284ad6fa1891fc639401c3caed26aL57-R62) [[4]](diffhunk://#diff-7f5084b797ed6a8d1d069525c80b5d1eb13284ad6fa1891fc639401c3caed26aL70-R76) [[5]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L28-R30) [[6]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L93-R96) [[7]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L112-R116)

**Code style and documentation improvements:**

- Improved code formatting and comments in migration scripts for better readability and maintainability, such as breaking long lines and updating section numbers in comments to reflect changes. [[1]](diffhunk://#diff-014ee364cd0ab2729dbc3247aee7966d63c249cd83df59e74db35f8426cd8824L28-R30) [[2]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L108-R89) [[3]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L125-R106) [[4]](diffhunk://#diff-199339c480aeab849e6b4177cad600baa1e2a59a5a6416187c8119a5e34c8a42L152-R133) [[5]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L115-R97) [[6]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L152-R134) [[7]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L177-R159) [[8]](diffhunk://#diff-77ffc51494e2fb8db1fbd9f370d93e45ad2e5a35b6eae07eca13c48055e20451L239-R221)

**Removal of obsolete configuration example:**

- Removed the `.env.example` file, which contained environment variable documentation and sample values for local development.