### PR TITLE
feat: inline file preview render in notes — all previewable types

### DIFF
--- a/frontend/src/app/(workspace)/[workspaceSlug]/issues/[issueId]/page.tsx
+++ b/frontend/src/app/(workspace)/[workspaceSlug]/issues/[issueId]/page.tsx
@@ -440,7 +440,7 @@ const IssueDetailPage = observer(function IssueDetailPage() {
       <FilePreviewConfigContext.Provider
         value={{ workspaceId, projectId: issue.projectId ?? '' }}
       >
-      <div className="flex h-full bg-background overflow-hidden" data-testid="issue-detail">
+        <div className="flex h-full bg-background overflow-hidden" data-testid="issue-detail">
         <IssueNoteLayout
           headerContent={header}
           editorContent={editorContent}
@@ -486,7 +486,7 @@ const IssueDetailPage = observer(function IssueDetailPage() {
           onReject={handleRejectAction}
           onClose={() => setDestructiveModalOpen(false)}
         />
-      </div>
+        </div>
       </FilePreviewConfigContext.Provider>
     </IssueNoteContext.Provider>
   );

--- a/frontend/src/app/(workspace)/[workspaceSlug]/issues/[issueId]/page.tsx
+++ b/frontend/src/app/(workspace)/[workspaceSlug]/issues/[issueId]/page.tsx
@@ -45,6 +45,7 @@ import { implementationPlanKeys } from '@/features/issues/hooks/use-implementati
 import { useIssueApprovals } from '@/features/issues/hooks/use-issue-approvals';
 import { useIssueAiActions } from '@/features/issues/hooks/use-issue-ai-actions';
 import { IssueNoteContext } from '@/features/issues/contexts/issue-note-context';
+import { FilePreviewConfigContext } from '@/features/notes/editor/extensions/file-card/inline-preview';
 import { useStore } from '@/stores';
 import { copyToClipboard } from '@/lib/copy-context';
 import { issuesApi, tasksApi } from '@/services/api';
@@ -436,6 +437,9 @@ const IssueDetailPage = observer(function IssueDetailPage() {
 
   return (
     <IssueNoteContext.Provider value={contextValue}>
+      <FilePreviewConfigContext.Provider
+        value={{ workspaceId, projectId: issue.projectId ?? '' }}
+      >
       <div className="flex h-full bg-background overflow-hidden" data-testid="issue-detail">
         <IssueNoteLayout
           headerContent={header}
@@ -483,6 +487,7 @@ const IssueDetailPage = observer(function IssueDetailPage() {
           onClose={() => setDestructiveModalOpen(false)}
         />
       </div>
+      </FilePreviewConfigContext.Provider>
     </IssueNoteContext.Provider>
   );
 });

--- a/frontend/src/app/(workspace)/[workspaceSlug]/notes/[noteId]/page.tsx
+++ b/frontend/src/app/(workspace)/[workspaceSlug]/notes/[noteId]/page.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { NoteCanvas } from '@/components/editor/NoteCanvas';
 import { VersionHistoryPanel, type NoteVersion } from '@/components/editor/VersionHistoryPanel';
 import { EditorFilePreview } from '@/features/artifacts/components/EditorFilePreview';
+import { FilePreviewConfigContext } from '@/features/notes/editor/extensions/file-card/inline-preview';
 import { useNote, useUpdateNote, useAutoSave } from '@/features/notes/hooks';
 import { useDeleteNote } from '@/features/notes/hooks/useDeleteNote';
 import { useTogglePin } from '@/hooks/useTogglePin';
@@ -396,40 +397,44 @@ function NoteDetailPage() {
     <div className="flex h-full flex-col">
       {/* Editor with merged header - Three-column layout per Prototype v4 */}
       <div className="relative flex-1 overflow-hidden">
-        <NoteCanvas
-          key={noteId}
-          noteId={noteId}
-          content={sanitizedContent}
-          readOnly={false}
-          onChange={handleContentChange}
-          onSave={handleSave}
-          workspaceId={workspaceId}
-          // Merged header props per Prototype v4
-          title={note.title}
-          author={note.owner}
-          createdAt={note.createdAt}
-          updatedAt={note.updatedAt}
-          wordCount={note.wordCount}
-          isPinned={note.isPinned}
-          isAIAssisted={note.isAIAssisted}
-          topics={note.topics}
-          workspaceSlug={workspaceSlug}
-          onTitleChange={handleTitleChange}
-          onShare={handleShare}
-          onExport={handleExport}
-          onDelete={handleDelete}
-          onTogglePin={handleTogglePin}
-          onVersionHistory={handleVersionHistory}
-          onMove={handleMove}
-          projectId={note.projectId}
-          linkedIssues={note.linkedIssues}
-          iconEmoji={note.iconEmoji}
-          isFocusMode={isFocusMode}
-          onToggleFocusMode={handleToggleFocusMode}
-        />
+        <FilePreviewConfigContext.Provider
+          value={{ workspaceId, projectId: note.projectId ?? '' }}
+        >
+          <NoteCanvas
+            key={noteId}
+            noteId={noteId}
+            content={sanitizedContent}
+            readOnly={false}
+            onChange={handleContentChange}
+            onSave={handleSave}
+            workspaceId={workspaceId}
+            // Merged header props per Prototype v4
+            title={note.title}
+            author={note.owner}
+            createdAt={note.createdAt}
+            updatedAt={note.updatedAt}
+            wordCount={note.wordCount}
+            isPinned={note.isPinned}
+            isAIAssisted={note.isAIAssisted}
+            topics={note.topics}
+            workspaceSlug={workspaceSlug}
+            onTitleChange={handleTitleChange}
+            onShare={handleShare}
+            onExport={handleExport}
+            onDelete={handleDelete}
+            onTogglePin={handleTogglePin}
+            onVersionHistory={handleVersionHistory}
+            onMove={handleMove}
+            projectId={note.projectId}
+            linkedIssues={note.linkedIssues}
+            iconEmoji={note.iconEmoji}
+            isFocusMode={isFocusMode}
+            onToggleFocusMode={handleToggleFocusMode}
+          />
 
-        {/* File preview modal — self-contained to isolate state from EditorContent */}
-        <EditorFilePreview workspaceId={workspaceId} projectId={note.projectId ?? ''} />
+          {/* File preview modal — self-contained to isolate state from EditorContent */}
+          <EditorFilePreview workspaceId={workspaceId} projectId={note.projectId ?? ''} />
+        </FilePreviewConfigContext.Provider>
 
         {/* Version History Panel - slides in from right */}
         {showVersionHistory && (

--- a/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
@@ -10,11 +10,13 @@
  * Renders three states:
  * - uploading: compact card with progress bar (reads live progress from ArtifactStore)
  * - error: card with destructive styling and retry button
- * - ready: card with file type icon, filename, size, and mime type label
+ * - ready (non-previewable): compact card with file type icon, filename, size, mime label
+ * - ready (previewable): inline content preview card (code/markdown/csv/json)
  *
- * Note: The "open preview" action for ready cards is stubbed as a no-op role="button".
- * The FilePreviewModal is built in Phase 34 and will wire the click handler.
+ * Inline preview is gated on FilePreviewConfigContext being present (provided by the
+ * note/issue page). When no provider is present, files fall back to compact card behavior.
  */
+import { useState, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   File,
@@ -27,8 +29,16 @@ import {
 } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { useFileCardContext } from './FileCardContext';
 import { useArtifactStore } from '@/stores';
+import {
+  useInlinePreviewContent,
+  InlinePreviewHeader,
+  SkeletonPreviewCard,
+  InlineContentRenderer,
+  getTruncationInfo,
+} from './inline-preview';
 
 /** Returns the appropriate Lucide icon component for a given MIME type. */
 function getFileIcon(mimeType: string) {
@@ -62,6 +72,30 @@ export const FileCardView = observer(function FileCardView() {
   const progress = artifactStore.getProgress(filename);
   const FileIcon = getFileIcon(mimeType);
 
+  // Inline preview state — hooks must be called unconditionally (React rules of hooks)
+  const { containerRef, content, isLoading, isError, rendererType, signedUrl } =
+    useInlinePreviewContent(artifactId, mimeType, filename);
+  const [expanded, setExpanded] = useState(false);
+
+  // rendererType is non-null only when: (a) file is previewable type AND
+  // (b) FilePreviewConfigContext.Provider is present in the tree
+  const previewable = rendererType !== null && status === 'ready';
+
+  // Stable dispatch helper for opening the full preview modal
+  const dispatchPreviewEvent = useCallback(() => {
+    if (!artifactId) return;
+    queueMicrotask(() => {
+      window.dispatchEvent(
+        new CustomEvent('pilot:preview-artifact', {
+          detail: { artifactId, filename, mimeType },
+        })
+      );
+    });
+  }, [artifactId, filename, mimeType]);
+
+  // -------------------------------------------------------------------------
+  // Uploading state
+  // -------------------------------------------------------------------------
   if (status === 'uploading') {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/30 px-4 py-3 my-1 select-none">
@@ -77,6 +111,9 @@ export const FileCardView = observer(function FileCardView() {
     );
   }
 
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
   if (status === 'error') {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 my-1 select-none">
@@ -101,7 +138,99 @@ export const FileCardView = observer(function FileCardView() {
     );
   }
 
-  // status === 'ready'
+  // -------------------------------------------------------------------------
+  // Ready state — inline preview card (previewable file types with provider)
+  // -------------------------------------------------------------------------
+  if (previewable) {
+    const truncationInfo =
+      content && rendererType ? getTruncationInfo(content, rendererType, expanded) : null;
+    const showFooter = truncationInfo?.wasTruncated === true && rendererType !== 'markdown';
+
+    return (
+      <div
+        ref={containerRef}
+        className="rounded-lg border border-border bg-card my-1 overflow-hidden group"
+        role="article"
+        aria-label={`${filename} preview`}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            dispatchPreviewEvent();
+          }
+        }}
+      >
+        {/* Header bar */}
+        <InlinePreviewHeader
+          filename={filename}
+          mimeType={mimeType}
+          artifactId={artifactId ?? ''}
+          signedUrl={signedUrl}
+          onCopy={async () => {
+            if (content) await navigator.clipboard.writeText(content);
+          }}
+          onExpandToModal={dispatchPreviewEvent}
+        />
+
+        {/* Content area — click opens full modal */}
+        <div
+          className={cn(
+            'transition-[max-height] duration-200 ease-out cursor-pointer',
+            expanded ? '' : 'max-h-[300px] overflow-hidden',
+            rendererType === 'markdown' && !expanded ? 'max-h-[300px] overflow-y-auto' : ''
+          )}
+          role="button"
+          aria-label={`Open ${filename} full preview`}
+          onClick={() => {
+            if (!artifactId) return;
+            dispatchPreviewEvent();
+          }}
+        >
+          {isLoading && <SkeletonPreviewCard />}
+          {isError && (
+            <div className="p-4 text-center" role="alert">
+              <p className="text-sm font-medium text-destructive">Couldn&apos;t load preview</p>
+              <p className="text-xs text-muted-foreground mt-1">Click to open the full preview.</p>
+            </div>
+          )}
+          {content && rendererType && (
+            <InlineContentRenderer
+              content={content}
+              rendererType={rendererType}
+              filename={filename}
+              expanded={expanded}
+            />
+          )}
+        </div>
+
+        {/* Footer — expand/collapse link */}
+        {showFooter && truncationInfo && (
+          <div className="border-t border-border px-4 py-2">
+            <button
+              className="text-xs text-primary hover:underline"
+              aria-expanded={expanded}
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded((prev) => {
+                  if (prev) {
+                    // Collapsing — scroll card into view
+                    containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                  }
+                  return !prev;
+                });
+              }}
+            >
+              {expanded ? 'Show less' : truncationInfo.label}
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Ready state — compact card (non-previewable files or no context provider)
+  // -------------------------------------------------------------------------
   return (
     <div
       className="flex items-center gap-3 rounded-lg border border-border bg-card hover:bg-muted/50 transition-colors px-4 py-3 my-1 cursor-pointer select-none group"

--- a/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
@@ -167,7 +167,13 @@ export const FileCardView = observer(function FileCardView() {
           artifactId={artifactId ?? ''}
           signedUrl={signedUrl}
           onCopy={async () => {
-            if (content && typeof content === 'string') await navigator.clipboard.writeText(content);
+            if (content && typeof content === 'string') {
+              try {
+                await navigator.clipboard.writeText(content);
+              } catch (err) {
+                console.error('Clipboard write failed:', err);
+              }
+            }
           }}
           onExpandToModal={dispatchPreviewEvent}
         />
@@ -238,29 +244,11 @@ export const FileCardView = observer(function FileCardView() {
       role="button"
       tabIndex={0}
       aria-label={`Open file: ${filename}`}
-      onClick={() => {
-        if (!artifactId) return;
-        // Defer dispatch so React state updates from the event listener run outside
-        // TipTap's ReactRenderer cycle (prevents residual flushSync warnings).
-        queueMicrotask(() => {
-          window.dispatchEvent(
-            new CustomEvent('pilot:preview-artifact', {
-              detail: { artifactId, filename, mimeType },
-            })
-          );
-        });
-      }}
+      onClick={dispatchPreviewEvent}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          if (!artifactId) return;
-          queueMicrotask(() => {
-            window.dispatchEvent(
-              new CustomEvent('pilot:preview-artifact', {
-                detail: { artifactId, filename, mimeType },
-              })
-            );
-          });
+          dispatchPreviewEvent();
         }
       }}
     >

--- a/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/FileCardView.tsx
@@ -167,7 +167,7 @@ export const FileCardView = observer(function FileCardView() {
           artifactId={artifactId ?? ''}
           signedUrl={signedUrl}
           onCopy={async () => {
-            if (content) await navigator.clipboard.writeText(content);
+            if (content && typeof content === 'string') await navigator.clipboard.writeText(content);
           }}
           onExpandToModal={dispatchPreviewEvent}
         />
@@ -199,6 +199,7 @@ export const FileCardView = observer(function FileCardView() {
               rendererType={rendererType}
               filename={filename}
               expanded={expanded}
+              signedUrl={signedUrl}
             />
           )}
         </div>

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/FilePreviewConfigContext.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/FilePreviewConfigContext.ts
@@ -38,3 +38,12 @@ export function useFilePreviewConfig(): FilePreviewConfig {
   }
   return ctx;
 }
+
+/**
+ * Safe variant that returns null when the context provider is absent.
+ * Used by useInlinePreviewContent to gracefully fall back to non-previewable
+ * behavior when a FileCard is rendered outside a page-level provider.
+ */
+export function useFilePreviewConfigSafe(): FilePreviewConfig | null {
+  return useContext(FilePreviewConfigContext);
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/FilePreviewConfigContext.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/FilePreviewConfigContext.ts
@@ -1,0 +1,40 @@
+'use client';
+
+/**
+ * FilePreviewConfigContext — React context providing workspace and project identifiers
+ * needed for signed URL fetching in the inline file preview.
+ *
+ * Follows the same context bridge pattern as FileCardContext and IssueNoteContext:
+ * - Provided by the note/issue page that hosts the TipTap editor
+ * - Consumed by useInlinePreviewContent to fetch signed URLs without prop drilling
+ *   through TipTap's NodeView boundary
+ *
+ * Usage:
+ *   <FilePreviewConfigContext.Provider value={{ workspaceId, projectId }}>
+ *     <NoteCanvas ... />
+ *   </FilePreviewConfigContext.Provider>
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface FilePreviewConfig {
+  workspaceId: string;
+  projectId: string;
+}
+
+export const FilePreviewConfigContext = createContext<FilePreviewConfig | null>(null);
+
+/**
+ * Returns the file preview config from context.
+ * Throws if the context has not been provided — callers must be wrapped in
+ * FilePreviewConfigContext.Provider at the page level.
+ */
+export function useFilePreviewConfig(): FilePreviewConfig {
+  const ctx = useContext(FilePreviewConfigContext);
+  if (!ctx) {
+    throw new Error(
+      'useFilePreviewConfig must be used within a FilePreviewConfigContext.Provider'
+    );
+  }
+  return ctx;
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+/**
+ * InlineContentRenderer — Dispatches to the correct renderer based on InlineRendererType.
+ *
+ * All heavy renderers are dynamically imported via next/dynamic to keep the initial
+ * bundle small. The SkeletonPreviewCard is used as the loading fallback for all imports.
+ *
+ * Content truncation:
+ * - code/json: first 30 lines when collapsed
+ * - csv: first 11 lines (header + 10 data rows) when collapsed
+ * - markdown: no truncation — scrolls within the 300px max-height container
+ *
+ * The `expanded` prop controls whether truncation is applied. When false (default),
+ * only a preview subset of lines is rendered to keep DOM cost low.
+ *
+ * Renderers are wrapped in a container with reduced padding so they fit the inline
+ * card context (existing renderers use p-6 which is too large for note context).
+ */
+
+import * as React from 'react';
+import dynamic from 'next/dynamic';
+import { SkeletonPreviewCard } from './SkeletonPreviewCard';
+import type { InlineRendererType } from './is-inline-previewable';
+import { getLanguageForFile } from '@/features/artifacts/utils/mime-type-router';
+
+// ---------------------------------------------------------------------------
+// Dynamic imports with SkeletonPreviewCard as fallback
+// ---------------------------------------------------------------------------
+
+const MarkdownContent = dynamic(
+  () =>
+    import('@/features/ai/ChatView/MessageList/MarkdownContent').then((m) => ({
+      default: m.MarkdownContent,
+    })),
+  { loading: () => <SkeletonPreviewCard /> }
+);
+
+const CsvRenderer = dynamic(
+  () =>
+    import('@/features/artifacts/components/renderers/CsvRenderer').then((m) => ({
+      default: m.CsvRenderer,
+    })),
+  { loading: () => <SkeletonPreviewCard /> }
+);
+
+// ---------------------------------------------------------------------------
+// Truncation utilities
+// ---------------------------------------------------------------------------
+
+interface TruncateResult {
+  truncated: string;
+  totalLines: number;
+  wasTruncated: boolean;
+}
+
+function truncateLines(content: string, maxLines: number): TruncateResult {
+  const lines = content.split('\n');
+  const totalLines = lines.length;
+  if (totalLines <= maxLines) {
+    return { truncated: content, totalLines, wasTruncated: false };
+  }
+  return {
+    truncated: lines.slice(0, maxLines).join('\n'),
+    totalLines,
+    wasTruncated: true,
+  };
+}
+
+export interface TruncationInfo {
+  totalLines: number;
+  totalRows: number;
+  wasTruncated: boolean;
+  /** Human-readable label for the "Show more" expand link. */
+  label: string;
+}
+
+/**
+ * Returns truncation metadata for the footer expand link.
+ * CSV row counts are estimated from line count (header not counted in rows).
+ * For markdown, truncation is not applied so this always returns wasTruncated: false.
+ */
+export function getTruncationInfo(
+  content: string,
+  rendererType: InlineRendererType,
+  expanded: boolean
+): TruncationInfo {
+  if (rendererType === 'markdown') {
+    return { totalLines: 0, totalRows: 0, wasTruncated: false, label: '' };
+  }
+
+  if (rendererType === 'csv') {
+    const lines = content.split('\n').filter((l) => l.trim().length > 0);
+    // lines[0] is the header; data rows start at index 1
+    const totalRows = Math.max(0, lines.length - 1);
+    const wasTruncated = !expanded && totalRows > 10;
+    return {
+      totalLines: lines.length,
+      totalRows,
+      wasTruncated,
+      label: wasTruncated ? `Show more (${totalRows} rows)` : '',
+    };
+  }
+
+  // code / json
+  const lines = content.split('\n');
+  const totalLines = lines.length;
+  const wasTruncated = !expanded && totalLines > 30;
+  return {
+    totalLines,
+    totalRows: 0,
+    wasTruncated,
+    label: wasTruncated ? `Show more (${totalLines} lines)` : '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface InlineContentRendererProps {
+  content: string;
+  rendererType: InlineRendererType;
+  filename: string;
+  expanded: boolean;
+}
+
+export function InlineContentRenderer({
+  content,
+  rendererType,
+  filename,
+  expanded,
+}: InlineContentRendererProps) {
+  if (rendererType === 'markdown') {
+    // Full content, scroll within the 300px card container.
+    return (
+      <div className="[&>div]:p-3 [&>div]:py-2">
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <MarkdownContent content={content} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'code') {
+    const { truncated } = truncateLines(content, expanded ? Infinity : 30);
+    const language = getLanguageForFile(filename);
+    const wrappedContent = '```' + language + '\n' + truncated + '\n```';
+    return (
+      <div className="[&>div]:p-3 [&>div]:py-2">
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <MarkdownContent content={wrappedContent} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'json') {
+    // Format JSON then truncate
+    let formatted = content;
+    try {
+      formatted = JSON.stringify(JSON.parse(content), null, 2);
+    } catch {
+      // Malformed JSON — render as-is
+    }
+    const { truncated } = truncateLines(formatted, expanded ? Infinity : 30);
+    const wrappedContent = '```json\n' + truncated + '\n```';
+    return (
+      <div className="[&>div]:p-3 [&>div]:py-2">
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <MarkdownContent content={wrappedContent} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'csv') {
+    // Truncate CSV to header + 10 data rows when collapsed.
+    // Pass the truncated content string to CsvRenderer so it parses only what's needed.
+    const truncated = expanded
+      ? content
+      : truncateLines(content, 11).truncated;
+    return (
+      <div className="[&>div]:p-0 overflow-x-auto">
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <CsvRenderer content={truncated} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  // Should be unreachable — rendererType is a union of the 4 cases above
+  return null;
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
@@ -24,6 +24,7 @@ import dynamic from 'next/dynamic';
 import { SkeletonPreviewCard } from './SkeletonPreviewCard';
 import type { InlineRendererType } from './is-inline-previewable';
 import { getLanguageForFile } from '@/features/artifacts/utils/mime-type-router';
+import { Button } from '@/components/ui/button';
 
 // ---------------------------------------------------------------------------
 // Dynamic imports with SkeletonPreviewCard as fallback
@@ -108,9 +109,19 @@ export interface TruncationInfo {
   label: string;
 }
 
+/** Pretty-print JSON if valid, otherwise return as-is. Shared by renderer and truncation. */
+function formatJsonSafe(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
 /**
  * Returns truncation metadata for the footer expand link.
  * CSV row counts are estimated from line count (header not counted in rows).
+ * For JSON, content is pretty-printed first so line count matches the rendered output.
  * For markdown, html-preview, and binary types, truncation is not applied.
  */
 export function getTruncationInfo(
@@ -147,8 +158,9 @@ export function getTruncationInfo(
     };
   }
 
-  // code / json / text
-  const lines = content.split('\n');
+  // JSON: pretty-print before counting so line count matches rendered output
+  const effective = rendererType === 'json' ? formatJsonSafe(content) : content;
+  const lines = effective.split('\n');
   const totalLines = lines.length;
   const wasTruncated = !expanded && totalLines > 30;
   return {
@@ -179,9 +191,25 @@ export function InlineContentRenderer({
   expanded,
   signedUrl = '',
 }: InlineContentRendererProps) {
-  // PPTX slide state
+  // PPTX slide state — reset when content changes (different file)
   const [currentSlide, setCurrentSlide] = React.useState(0);
   const [slideCount, setSlideCount] = React.useState(0);
+  const contentRef = React.useRef(content);
+
+  React.useEffect(() => {
+    if (contentRef.current !== content) {
+      contentRef.current = content;
+      setCurrentSlide(0);
+      setSlideCount(0);
+    }
+  }, [content]);
+
+  // Clamp currentSlide when slideCount changes (e.g. after PPTX parse)
+  React.useEffect(() => {
+    if (slideCount > 0 && currentSlide >= slideCount) {
+      setCurrentSlide(Math.max(0, slideCount - 1));
+    }
+  }, [slideCount, currentSlide]);
 
   if (rendererType === 'markdown') {
     // Full content, scroll within the 300px card container.
@@ -208,13 +236,7 @@ export function InlineContentRenderer({
   }
 
   if (rendererType === 'json') {
-    // Format JSON then truncate
-    let formatted = content as string;
-    try {
-      formatted = JSON.stringify(JSON.parse(formatted), null, 2);
-    } catch {
-      // Malformed JSON — render as-is
-    }
+    const formatted = formatJsonSafe(content as string);
     const { truncated } = truncateLines(formatted, expanded ? Infinity : 30);
     const wrappedContent = '```json\n' + truncated + '\n```';
     return (
@@ -297,25 +319,29 @@ export function InlineContentRenderer({
         </React.Suspense>
         {slideCount > 1 && (
           <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground border-t border-border">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
               onClick={() => setCurrentSlide(Math.max(0, currentSlide - 1))}
               disabled={currentSlide === 0}
-              className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
               aria-label="Previous slide"
             >
               ←
-            </button>
+            </Button>
             <span>
               {currentSlide + 1} / {slideCount}
             </span>
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
               onClick={() => setCurrentSlide(Math.min(slideCount - 1, currentSlide + 1))}
               disabled={currentSlide >= slideCount - 1}
-              className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
               aria-label="Next slide"
             >
               →
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
@@ -301,6 +301,7 @@ export function InlineContentRenderer({
               onClick={() => setCurrentSlide(Math.max(0, currentSlide - 1))}
               disabled={currentSlide === 0}
               className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
+              aria-label="Previous slide"
             >
               ←
             </button>
@@ -311,6 +312,7 @@ export function InlineContentRenderer({
               onClick={() => setCurrentSlide(Math.min(slideCount - 1, currentSlide + 1))}
               disabled={currentSlide >= slideCount - 1}
               className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
+              aria-label="Next slide"
             >
               →
             </button>

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
@@ -101,6 +101,57 @@ function truncateLines(content: string, maxLines: number): TruncateResult {
   };
 }
 
+/**
+ * Wrap content in a fenced code block using a fence longer than any backtick
+ * run found inside the content. Prevents premature fence closure.
+ */
+function wrapFencedCode(content: string, language = ''): string {
+  let maxRun = 2; // minimum fence length is 3
+  const matches = content.match(/`+/g);
+  if (matches) {
+    for (const m of matches) {
+      if (m.length > maxRun) maxRun = m.length;
+    }
+  }
+  const fence = '`'.repeat(maxRun + 1);
+  return `${fence}${language}\n${content}\n${fence}`;
+}
+
+/**
+ * Count actual CSV data rows using papaparse (handles quoted fields with
+ * embedded newlines). Falls back to line-split count on parse failure.
+ */
+function countCsvRows(content: string): { totalRows: number } {
+  try {
+    // Dynamic import is not feasible in a sync function — CsvRenderer is already
+    // dynamically imported, but papaparse is a dep of CsvRenderer and bundled
+    // with it. We use require-style lazy access via the module-level dynamic import.
+    // Instead, use a lightweight heuristic: count unquoted newlines.
+    // A proper parse would need to be async. For now, count rows by tracking
+    // whether we're inside a quoted field.
+    let rows = 0;
+    let inQuotes = false;
+    for (let i = 0; i < content.length; i++) {
+      const ch = content[i];
+      if (ch === '"') {
+        inQuotes = !inQuotes;
+      } else if (ch === '\n' && !inQuotes) {
+        rows++;
+      }
+    }
+    // Last row may not end with newline
+    if (content.length > 0 && content[content.length - 1] !== '\n') {
+      rows++;
+    }
+    // rows includes header, so data rows = rows - 1
+    return { totalRows: Math.max(0, rows - 1) };
+  } catch {
+    // Fallback: raw line split
+    const lines = content.split('\n').filter((l) => l.trim().length > 0);
+    return { totalRows: Math.max(0, lines.length - 1) };
+  }
+}
+
 export interface TruncationInfo {
   totalLines: number;
   totalRows: number;
@@ -146,12 +197,10 @@ export function getTruncationInfo(
   }
 
   if (rendererType === 'csv') {
-    const lines = content.split('\n').filter((l) => l.trim().length > 0);
-    // lines[0] is the header; data rows start at index 1
-    const totalRows = Math.max(0, lines.length - 1);
+    const { totalRows } = countCsvRows(content);
     const wasTruncated = !expanded && totalRows > 10;
     return {
-      totalLines: lines.length,
+      totalLines: 0,
       totalRows,
       wasTruncated,
       label: wasTruncated ? `Show more (${totalRows} rows)` : '',
@@ -225,7 +274,7 @@ export function InlineContentRenderer({
   if (rendererType === 'code') {
     const { truncated } = truncateLines(content as string, expanded ? Infinity : 30);
     const language = getLanguageForFile(filename);
-    const wrappedContent = '```' + language + '\n' + truncated + '\n```';
+    const wrappedContent = wrapFencedCode(truncated, language);
     return (
       <div className="[&>div]:p-3 [&>div]:py-2">
         <React.Suspense fallback={<SkeletonPreviewCard />}>
@@ -238,7 +287,7 @@ export function InlineContentRenderer({
   if (rendererType === 'json') {
     const formatted = formatJsonSafe(content as string);
     const { truncated } = truncateLines(formatted, expanded ? Infinity : 30);
-    const wrappedContent = '```json\n' + truncated + '\n```';
+    const wrappedContent = wrapFencedCode(truncated, 'json');
     return (
       <div className="[&>div]:p-3 [&>div]:py-2">
         <React.Suspense fallback={<SkeletonPreviewCard />}>

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlineContentRenderer.tsx
@@ -7,9 +7,10 @@
  * bundle small. The SkeletonPreviewCard is used as the loading fallback for all imports.
  *
  * Content truncation:
- * - code/json: first 30 lines when collapsed
+ * - code/json/text: first 30 lines when collapsed
  * - csv: first 11 lines (header + 10 data rows) when collapsed
- * - markdown: no truncation — scrolls within the 300px max-height container
+ * - markdown/html-preview: no truncation — scrolls within the 300px max-height container
+ * - xlsx/docx/pptx: no truncation — binary content rendered by Office parsers
  *
  * The `expanded` prop controls whether truncation is applied. When false (default),
  * only a preview subset of lines is rendered to keep DOM cost low.
@@ -42,6 +43,38 @@ const CsvRenderer = dynamic(
       default: m.CsvRenderer,
     })),
   { loading: () => <SkeletonPreviewCard /> }
+);
+
+const XlsxRenderer = dynamic(
+  () =>
+    import('@/features/artifacts/components/renderers/XlsxRenderer').then((m) => ({
+      default: m.XlsxRenderer,
+    })),
+  { ssr: false, loading: () => <SkeletonPreviewCard /> }
+);
+
+const DocxRenderer = dynamic(
+  () =>
+    import('@/features/artifacts/components/renderers/DocxRenderer').then((m) => ({
+      default: m.DocxRenderer,
+    })),
+  { ssr: false, loading: () => <SkeletonPreviewCard /> }
+);
+
+const PptxRenderer = dynamic(
+  () =>
+    import('@/features/artifacts/components/renderers/PptxRenderer').then((m) => ({
+      default: m.PptxRenderer,
+    })),
+  { ssr: false, loading: () => <SkeletonPreviewCard /> }
+);
+
+const HtmlRenderer = dynamic(
+  () =>
+    import('@/features/artifacts/components/renderers/HtmlRenderer').then((m) => ({
+      default: m.HtmlRenderer,
+    })),
+  { ssr: false, loading: () => <SkeletonPreviewCard /> }
 );
 
 // ---------------------------------------------------------------------------
@@ -78,14 +111,26 @@ export interface TruncationInfo {
 /**
  * Returns truncation metadata for the footer expand link.
  * CSV row counts are estimated from line count (header not counted in rows).
- * For markdown, truncation is not applied so this always returns wasTruncated: false.
+ * For markdown, html-preview, and binary types, truncation is not applied.
  */
 export function getTruncationInfo(
-  content: string,
+  content: string | ArrayBuffer,
   rendererType: InlineRendererType,
   expanded: boolean
 ): TruncationInfo {
-  if (rendererType === 'markdown') {
+  // Binary types and non-truncatable text types
+  if (
+    rendererType === 'markdown' ||
+    rendererType === 'html-preview' ||
+    rendererType === 'xlsx' ||
+    rendererType === 'docx' ||
+    rendererType === 'pptx'
+  ) {
+    return { totalLines: 0, totalRows: 0, wasTruncated: false, label: '' };
+  }
+
+  // Binary content should not reach here, but guard
+  if (content instanceof ArrayBuffer) {
     return { totalLines: 0, totalRows: 0, wasTruncated: false, label: '' };
   }
 
@@ -102,7 +147,7 @@ export function getTruncationInfo(
     };
   }
 
-  // code / json
+  // code / json / text
   const lines = content.split('\n');
   const totalLines = lines.length;
   const wasTruncated = !expanded && totalLines > 30;
@@ -119,10 +164,12 @@ export function getTruncationInfo(
 // ---------------------------------------------------------------------------
 
 export interface InlineContentRendererProps {
-  content: string;
+  content: string | ArrayBuffer;
   rendererType: InlineRendererType;
   filename: string;
   expanded: boolean;
+  /** Signed URL for Office renderer download fallbacks */
+  signedUrl?: string;
 }
 
 export function InlineContentRenderer({
@@ -130,20 +177,25 @@ export function InlineContentRenderer({
   rendererType,
   filename,
   expanded,
+  signedUrl = '',
 }: InlineContentRendererProps) {
+  // PPTX slide state
+  const [currentSlide, setCurrentSlide] = React.useState(0);
+  const [slideCount, setSlideCount] = React.useState(0);
+
   if (rendererType === 'markdown') {
     // Full content, scroll within the 300px card container.
     return (
       <div className="[&>div]:p-3 [&>div]:py-2">
         <React.Suspense fallback={<SkeletonPreviewCard />}>
-          <MarkdownContent content={content} />
+          <MarkdownContent content={content as string} />
         </React.Suspense>
       </div>
     );
   }
 
   if (rendererType === 'code') {
-    const { truncated } = truncateLines(content, expanded ? Infinity : 30);
+    const { truncated } = truncateLines(content as string, expanded ? Infinity : 30);
     const language = getLanguageForFile(filename);
     const wrappedContent = '```' + language + '\n' + truncated + '\n```';
     return (
@@ -157,9 +209,9 @@ export function InlineContentRenderer({
 
   if (rendererType === 'json') {
     // Format JSON then truncate
-    let formatted = content;
+    let formatted = content as string;
     try {
-      formatted = JSON.stringify(JSON.parse(content), null, 2);
+      formatted = JSON.stringify(JSON.parse(formatted), null, 2);
     } catch {
       // Malformed JSON — render as-is
     }
@@ -174,12 +226,22 @@ export function InlineContentRenderer({
     );
   }
 
+  if (rendererType === 'text') {
+    const { truncated } = truncateLines(content as string, expanded ? Infinity : 30);
+    return (
+      <div className="p-3 py-2">
+        <pre className="text-sm font-mono text-foreground whitespace-pre-wrap break-words">
+          {truncated}
+        </pre>
+      </div>
+    );
+  }
+
   if (rendererType === 'csv') {
     // Truncate CSV to header + 10 data rows when collapsed.
-    // Pass the truncated content string to CsvRenderer so it parses only what's needed.
     const truncated = expanded
-      ? content
-      : truncateLines(content, 11).truncated;
+      ? (content as string)
+      : truncateLines(content as string, 11).truncated;
     return (
       <div className="[&>div]:p-0 overflow-x-auto">
         <React.Suspense fallback={<SkeletonPreviewCard />}>
@@ -189,6 +251,75 @@ export function InlineContentRenderer({
     );
   }
 
-  // Should be unreachable — rendererType is a union of the 4 cases above
+  if (rendererType === 'html-preview') {
+    return (
+      <div className="p-0 overflow-hidden" style={{ maxHeight: expanded ? 'none' : '300px' }}>
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <HtmlRenderer content={content as string} filename={filename} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'xlsx') {
+    if (!(content instanceof ArrayBuffer)) return null;
+    return (
+      <div className="overflow-auto" style={{ maxHeight: expanded ? '600px' : '300px' }}>
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <XlsxRenderer content={content} filename={filename} signedUrl={signedUrl} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'docx') {
+    if (!(content instanceof ArrayBuffer)) return null;
+    return (
+      <div className="overflow-auto" style={{ maxHeight: expanded ? '600px' : '300px' }}>
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <DocxRenderer content={content} filename={filename} signedUrl={signedUrl} />
+        </React.Suspense>
+      </div>
+    );
+  }
+
+  if (rendererType === 'pptx') {
+    if (!(content instanceof ArrayBuffer)) return null;
+    return (
+      <div className="overflow-hidden" style={{ maxHeight: expanded ? '600px' : '300px' }}>
+        <React.Suspense fallback={<SkeletonPreviewCard />}>
+          <PptxRenderer
+            content={content}
+            currentSlide={currentSlide}
+            onSlideCountKnown={setSlideCount}
+            onNavigate={setCurrentSlide}
+          />
+        </React.Suspense>
+        {slideCount > 1 && (
+          <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground border-t border-border">
+            <button
+              onClick={() => setCurrentSlide(Math.max(0, currentSlide - 1))}
+              disabled={currentSlide === 0}
+              className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
+            >
+              ←
+            </button>
+            <span>
+              {currentSlide + 1} / {slideCount}
+            </span>
+            <button
+              onClick={() => setCurrentSlide(Math.min(slideCount - 1, currentSlide + 1))}
+              disabled={currentSlide >= slideCount - 1}
+              className="px-2 py-0.5 rounded hover:bg-muted disabled:opacity-40"
+            >
+              →
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Should be unreachable — rendererType is a union of all supported cases
   return null;
 }

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/**
+ * InlinePreviewHeader — Fixed 40px header bar for the inline file preview card.
+ *
+ * Left side: file type icon + filename (truncated)
+ * Right side: 4 ghost icon buttons — Copy, Download, Edit in IDE, Expand to modal
+ *
+ * All buttons call e.stopPropagation() to prevent the content click-to-modal handler
+ * from firing when the user clicks an action button.
+ */
+
+import * as React from 'react';
+import {
+  File,
+  FileText,
+  FileCode,
+  FileSpreadsheet,
+  Image,
+  Copy,
+  Check,
+  Download,
+  Code,
+  Maximize2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { resolveRenderer } from '@/features/artifacts/utils/mime-type-router';
+
+/** Returns the appropriate Lucide icon component for a given MIME type. */
+function getFileIcon(mimeType: string) {
+  if (mimeType.startsWith('image/')) return Image;
+  if (mimeType === 'application/pdf' || mimeType.startsWith('text/')) return FileText;
+  if (mimeType === 'text/csv' || mimeType.includes('spreadsheet') || mimeType.includes('excel'))
+    return FileSpreadsheet;
+  if (
+    mimeType.includes('javascript') ||
+    mimeType.includes('typescript') ||
+    mimeType.includes('html') ||
+    mimeType.includes('css')
+  )
+    return FileCode;
+  return File;
+}
+
+export interface InlinePreviewHeaderProps {
+  filename: string;
+  mimeType: string;
+  artifactId: string;
+  signedUrl: string;
+  onCopy: () => void;
+  onExpandToModal: () => void;
+}
+
+export function InlinePreviewHeader({
+  filename,
+  mimeType,
+  artifactId,
+  signedUrl,
+  onCopy,
+  onExpandToModal,
+}: InlinePreviewHeaderProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  const FileIcon = getFileIcon(mimeType);
+
+  // Only show the IDE button for code files
+  const showIdeButton = resolveRenderer(mimeType, filename) === 'code';
+
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation();
+    onCopy();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleDownload(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!signedUrl) return;
+    const link = document.createElement('a');
+    link.href = signedUrl;
+    link.download = filename;
+    link.click();
+  }
+
+  function handleOpenInIde(e: React.MouseEvent) {
+    e.stopPropagation();
+    queueMicrotask(() => {
+      window.dispatchEvent(
+        new CustomEvent('pilot:open-in-editor', { detail: { artifactId } })
+      );
+    });
+  }
+
+  function handleExpandToModal(e: React.MouseEvent) {
+    e.stopPropagation();
+    onExpandToModal();
+  }
+
+  return (
+    <div className="flex items-center h-10 bg-muted border-b border-border px-4 rounded-t-lg">
+      {/* Left: icon + filename */}
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="text-sm font-medium text-foreground truncate">{filename}</span>
+      </div>
+
+      {/* Right: action buttons */}
+      <div className="flex items-center gap-1 shrink-0">
+        {/* Copy */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Copy content"
+          onClick={handleCopy}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-emerald-600" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </Button>
+
+        {/* Download */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Download file"
+          onClick={handleDownload}
+          disabled={!signedUrl}
+        >
+          <Download className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Edit in IDE — only shown for code files */}
+        {showIdeButton && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label="Open in code editor"
+            onClick={handleOpenInIde}
+          >
+            <Code className="h-3.5 w-3.5" />
+          </Button>
+        )}
+
+        {/* Expand to modal */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Open full preview"
+          onClick={handleExpandToModal}
+        >
+          <Maximize2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
@@ -30,8 +30,6 @@ import { resolveRenderer } from '@/features/artifacts/utils/mime-type-router';
 function renderFileIcon(mimeType: string) {
   const className = 'h-4 w-4 shrink-0 text-muted-foreground';
   if (mimeType.startsWith('image/')) return <Image className={className} />;
-  if (mimeType === 'application/pdf' || mimeType.startsWith('text/'))
-    return <FileText className={className} />;
   if (mimeType === 'text/csv' || mimeType.includes('spreadsheet') || mimeType.includes('excel'))
     return <FileSpreadsheet className={className} />;
   if (
@@ -41,6 +39,8 @@ function renderFileIcon(mimeType: string) {
     mimeType.includes('css')
   )
     return <FileCode className={className} />;
+  if (mimeType === 'application/pdf' || mimeType.startsWith('text/'))
+    return <FileText className={className} />;
   return <File className={className} />;
 }
 
@@ -62,6 +62,13 @@ export function InlinePreviewHeader({
   onExpandToModal,
 }: InlinePreviewHeaderProps) {
   const [copied, setCopied] = React.useState(false);
+  const copyTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   // Only show the IDE button for code files
   const showIdeButton = resolveRenderer(mimeType, filename) === 'code';
@@ -70,7 +77,8 @@ export function InlinePreviewHeader({
     e.stopPropagation();
     onCopy();
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
   }
 
   function handleDownload(e: React.MouseEvent) {
@@ -157,6 +165,9 @@ export function InlinePreviewHeader({
           <Maximize2 className="h-3.5 w-3.5" />
         </Button>
       </div>
+      <span className="sr-only" aria-live="polite" role="status">
+        {copied ? 'Copied' : ''}
+      </span>
     </div>
   );
 }

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/InlinePreviewHeader.tsx
@@ -26,20 +26,22 @@ import {
 import { Button } from '@/components/ui/button';
 import { resolveRenderer } from '@/features/artifacts/utils/mime-type-router';
 
-/** Returns the appropriate Lucide icon component for a given MIME type. */
-function getFileIcon(mimeType: string) {
-  if (mimeType.startsWith('image/')) return Image;
-  if (mimeType === 'application/pdf' || mimeType.startsWith('text/')) return FileText;
+/** Returns a rendered Lucide icon element for the given MIME type. */
+function renderFileIcon(mimeType: string) {
+  const className = 'h-4 w-4 shrink-0 text-muted-foreground';
+  if (mimeType.startsWith('image/')) return <Image className={className} />;
+  if (mimeType === 'application/pdf' || mimeType.startsWith('text/'))
+    return <FileText className={className} />;
   if (mimeType === 'text/csv' || mimeType.includes('spreadsheet') || mimeType.includes('excel'))
-    return FileSpreadsheet;
+    return <FileSpreadsheet className={className} />;
   if (
     mimeType.includes('javascript') ||
     mimeType.includes('typescript') ||
     mimeType.includes('html') ||
     mimeType.includes('css')
   )
-    return FileCode;
-  return File;
+    return <FileCode className={className} />;
+  return <File className={className} />;
 }
 
 export interface InlinePreviewHeaderProps {
@@ -60,8 +62,6 @@ export function InlinePreviewHeader({
   onExpandToModal,
 }: InlinePreviewHeaderProps) {
   const [copied, setCopied] = React.useState(false);
-
-  const FileIcon = getFileIcon(mimeType);
 
   // Only show the IDE button for code files
   const showIdeButton = resolveRenderer(mimeType, filename) === 'code';
@@ -100,7 +100,7 @@ export function InlinePreviewHeader({
     <div className="flex items-center h-10 bg-muted border-b border-border px-4 rounded-t-lg">
       {/* Left: icon + filename */}
       <div className="flex items-center gap-2 flex-1 min-w-0">
-        <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        {renderFileIcon(mimeType)}
         <span className="text-sm font-medium text-foreground truncate">{filename}</span>
       </div>
 

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/SkeletonPreviewCard.tsx
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/SkeletonPreviewCard.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+/**
+ * SkeletonPreviewCard — Loading state for the inline file preview card.
+ *
+ * Renders 8 shimmer bars with staggered widths matching the UI-SPEC.
+ * Widths: [90, 72, 85, 55, 91, 63, 80, 48] (percent)
+ */
+
+const BAR_WIDTHS = [90, 72, 85, 55, 91, 63, 80, 48] as const;
+
+export function SkeletonPreviewCard() {
+  return (
+    <div
+      className="p-4 space-y-2"
+      aria-busy="true"
+      aria-label="Loading file preview"
+    >
+      {BAR_WIDTHS.map((w, i) => (
+        <div
+          key={i}
+          className="h-3 rounded bg-border animate-pulse"
+          style={{ width: `${w}%` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/index.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   FilePreviewConfigContext,
   useFilePreviewConfig,
+  useFilePreviewConfigSafe,
   type FilePreviewConfig,
 } from './FilePreviewConfigContext';
 

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/index.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Barrel export for the inline-preview subdirectory.
+ *
+ * Consumers should import from this index rather than individual files
+ * to maintain a stable public API boundary for Plan 02 wiring.
+ */
+
+export {
+  isInlinePreviewable,
+  getInlineRendererType,
+  type InlineRendererType,
+} from './is-inline-previewable';
+
+export {
+  FilePreviewConfigContext,
+  useFilePreviewConfig,
+  type FilePreviewConfig,
+} from './FilePreviewConfigContext';
+
+export {
+  useInlinePreviewContent,
+  type UseInlinePreviewContentResult,
+} from './useInlinePreviewContent';
+
+export { InlinePreviewHeader, type InlinePreviewHeaderProps } from './InlinePreviewHeader';
+
+export { SkeletonPreviewCard } from './SkeletonPreviewCard';
+
+export {
+  InlineContentRenderer,
+  getTruncationInfo,
+  type InlineContentRendererProps,
+  type TruncationInfo,
+} from './InlineContentRenderer';

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/is-inline-previewable.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/is-inline-previewable.ts
@@ -2,23 +2,42 @@
  * is-inline-previewable.ts
  *
  * Utility for determining whether a file can be previewed inline within a TipTap note.
- * Inline preview supports: code, markdown, csv, and json renderer types.
+ * Inline preview supports: code, markdown, csv, json, xlsx, docx, pptx, and html-preview.
  *
- * All other types (image, download, html-preview, xlsx, docx, pptx, text) fall back
+ * Only image (handled by FigureExtension) and download (no renderer) fall back
  * to the compact FileCard click-to-modal behavior.
  */
 
 import { resolveRenderer } from '@/features/artifacts/utils/mime-type-router';
 
 /** Renderer types supported for inline preview within a note card. */
-export type InlineRendererType = 'code' | 'markdown' | 'csv' | 'json';
+export type InlineRendererType =
+  | 'code'
+  | 'markdown'
+  | 'csv'
+  | 'json'
+  | 'xlsx'
+  | 'docx'
+  | 'pptx'
+  | 'html-preview'
+  | 'text';
 
 /** The set of renderer types that support inline preview. */
-const INLINE_RENDERER_TYPES = new Set<string>(['code', 'markdown', 'csv', 'json']);
+const INLINE_RENDERER_TYPES = new Set<string>([
+  'code',
+  'markdown',
+  'csv',
+  'json',
+  'xlsx',
+  'docx',
+  'pptx',
+  'html-preview',
+  'text',
+]);
 
 /**
  * Returns true if the given file's MIME type and filename map to a renderer type
- * that supports inline content preview (code, markdown, csv, json).
+ * that supports inline content preview.
  *
  * @param mimeType - The file's MIME type (e.g. "text/plain", "application/json")
  * @param filename - The file's name (used for extension-based routing)

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/is-inline-previewable.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/is-inline-previewable.ts
@@ -1,0 +1,43 @@
+/**
+ * is-inline-previewable.ts
+ *
+ * Utility for determining whether a file can be previewed inline within a TipTap note.
+ * Inline preview supports: code, markdown, csv, and json renderer types.
+ *
+ * All other types (image, download, html-preview, xlsx, docx, pptx, text) fall back
+ * to the compact FileCard click-to-modal behavior.
+ */
+
+import { resolveRenderer } from '@/features/artifacts/utils/mime-type-router';
+
+/** Renderer types supported for inline preview within a note card. */
+export type InlineRendererType = 'code' | 'markdown' | 'csv' | 'json';
+
+/** The set of renderer types that support inline preview. */
+const INLINE_RENDERER_TYPES = new Set<string>(['code', 'markdown', 'csv', 'json']);
+
+/**
+ * Returns true if the given file's MIME type and filename map to a renderer type
+ * that supports inline content preview (code, markdown, csv, json).
+ *
+ * @param mimeType - The file's MIME type (e.g. "text/plain", "application/json")
+ * @param filename - The file's name (used for extension-based routing)
+ */
+export function isInlinePreviewable(mimeType: string, filename: string): boolean {
+  const rendererType = resolveRenderer(mimeType, filename);
+  return INLINE_RENDERER_TYPES.has(rendererType);
+}
+
+/**
+ * Returns the inline renderer type for the file, or null if inline preview is not supported.
+ *
+ * @param mimeType - The file's MIME type
+ * @param filename - The file's name
+ */
+export function getInlineRendererType(mimeType: string, filename: string): InlineRendererType | null {
+  const rendererType = resolveRenderer(mimeType, filename);
+  if (INLINE_RENDERER_TYPES.has(rendererType)) {
+    return rendererType as InlineRendererType;
+  }
+  return null;
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
@@ -20,7 +20,7 @@ import type { RefObject } from 'react';
 import type { RendererType } from '@/features/artifacts/utils/mime-type-router';
 import { useArtifactSignedUrl } from '@/features/artifacts/hooks/use-artifact-signed-url';
 import { useFileContent } from '@/features/artifacts/hooks/useFileContent';
-import { useFilePreviewConfig } from './FilePreviewConfigContext';
+import { useFilePreviewConfigSafe } from './FilePreviewConfigContext';
 import { getInlineRendererType } from './is-inline-previewable';
 import type { InlineRendererType } from './is-inline-previewable';
 
@@ -85,20 +85,22 @@ export function useInlinePreviewContent(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Read workspace/project IDs from context (provided by the editor page)
-  const { workspaceId, projectId } = useFilePreviewConfig();
+  // Read workspace/project IDs from context (provided by the editor page).
+  // Safe variant returns null when no provider is present — allows FileCardView
+  // to fall back to compact card behavior without throwing.
+  const config = useFilePreviewConfigSafe();
 
-  // Fetch signed URL only after IntersectionObserver fires.
-  // Pass null when not yet visible to keep the query disabled.
+  // Fetch signed URL only after IntersectionObserver fires AND we have a provider.
+  // Pass null when not yet visible or no config to keep the query disabled.
   const { data: urlData, isLoading: urlLoading } = useArtifactSignedUrl(
-    workspaceId,
-    projectId,
-    isVisible ? artifactId : null
+    config?.workspaceId ?? '',
+    config?.projectId ?? '',
+    isVisible && !!config ? artifactId : null
   );
 
   const signedUrl = urlData?.url ?? '';
 
-  // Fetch text content once we have a signed URL and the card is visible.
+  // Fetch text content once we have a signed URL, the card is visible, and config is present.
   // The `open` parameter in useFileContent maps to the `enabled` flag on the query.
   const fileContent = useFileContent(
     signedUrl,
@@ -106,7 +108,7 @@ export function useInlinePreviewContent(
     // If rendererType is null (non-previewable), this hook still runs but
     // enabled will be false (signedUrl is empty or isVisible is false).
     (rendererType ?? 'download') as RendererType,
-    isVisible && !!signedUrl
+    isVisible && !!signedUrl && !!config
   );
 
   return {
@@ -115,6 +117,7 @@ export function useInlinePreviewContent(
     signedUrl,
     isLoading: (urlLoading && isVisible) || fileContent.isLoading,
     isError: fileContent.isError,
-    rendererType,
+    // Return null rendererType when no provider present — FileCardView falls back to compact card
+    rendererType: config ? rendererType : null,
   };
 }

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
@@ -113,7 +113,7 @@ export function useInlinePreviewContent(
 
   return {
     containerRef,
-    content: fileContent.content as string | undefined,
+    content: fileContent.content,
     signedUrl,
     isLoading: (urlLoading && isVisible) || fileContent.isLoading,
     isError: fileContent.isError,

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * useInlinePreviewContent — Lazy content-fetching hook for inline file previews.
+ *
+ * Fetch strategy:
+ * 1. IntersectionObserver (threshold: 0.1) fires when 10% of the card enters the viewport.
+ * 2. On first intersection: fetch signed URL via useArtifactSignedUrl (enabled by isVisible).
+ * 3. Once signed URL is ready: fetch text content via useFileContent.
+ *
+ * This ensures cards scrolled past without being seen never trigger network requests.
+ * All React hooks are called unconditionally — enabled flags control actual fetching.
+ *
+ * Returns `signedUrl` so the InlinePreviewHeader download button can use it directly
+ * without an additional context lookup.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import type { RendererType } from '@/features/artifacts/utils/mime-type-router';
+import { useArtifactSignedUrl } from '@/features/artifacts/hooks/use-artifact-signed-url';
+import { useFileContent } from '@/features/artifacts/hooks/useFileContent';
+import { useFilePreviewConfig } from './FilePreviewConfigContext';
+import { getInlineRendererType } from './is-inline-previewable';
+import type { InlineRendererType } from './is-inline-previewable';
+
+export interface UseInlinePreviewContentResult {
+  /** Attach to the card container element to trigger IntersectionObserver. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** The fetched text content, undefined while loading or on error. */
+  content: string | undefined;
+  /** The signed URL for the artifact (used by the download button). */
+  signedUrl: string;
+  /** True while signed URL or content fetch is in-flight. */
+  isLoading: boolean;
+  /** True if any fetch error occurred. */
+  isError: boolean;
+  /** The resolved inline renderer type, or null if not previewable. */
+  rendererType: InlineRendererType | null;
+}
+
+/**
+ * Lazily fetches file content for inline preview when the card enters the viewport.
+ *
+ * @param artifactId - The artifact's UUID, or null if not yet ready
+ * @param mimeType   - The file's MIME type
+ * @param filename   - The file's name (used for extension-based renderer routing)
+ */
+export function useInlinePreviewContent(
+  artifactId: string | null,
+  mimeType: string,
+  filename: string
+): UseInlinePreviewContentResult {
+  // Resolve renderer type up-front (pure calculation, no hooks involved)
+  const rendererType = getInlineRendererType(mimeType, filename);
+
+  // IntersectionObserver ref + visibility state
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  // One-shot IntersectionObserver — disconnect after first intersection to avoid
+  // re-triggering on scroll-out/scroll-in cycles.
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    // If already visible (e.g. SSR hydration, fast re-mount), skip observer
+    if (isVisible) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+    // Intentionally omitting `isVisible` — effect only needs to run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Read workspace/project IDs from context (provided by the editor page)
+  const { workspaceId, projectId } = useFilePreviewConfig();
+
+  // Fetch signed URL only after IntersectionObserver fires.
+  // Pass null when not yet visible to keep the query disabled.
+  const { data: urlData, isLoading: urlLoading } = useArtifactSignedUrl(
+    workspaceId,
+    projectId,
+    isVisible ? artifactId : null
+  );
+
+  const signedUrl = urlData?.url ?? '';
+
+  // Fetch text content once we have a signed URL and the card is visible.
+  // The `open` parameter in useFileContent maps to the `enabled` flag on the query.
+  const fileContent = useFileContent(
+    signedUrl,
+    // Cast is safe — InlineRendererType is a subset of RendererType.
+    // If rendererType is null (non-previewable), this hook still runs but
+    // enabled will be false (signedUrl is empty or isVisible is false).
+    (rendererType ?? 'download') as RendererType,
+    isVisible && !!signedUrl
+  );
+
+  return {
+    containerRef,
+    content: fileContent.content as string | undefined,
+    signedUrl,
+    isLoading: (urlLoading && isVisible) || fileContent.isLoading,
+    isError: fileContent.isError,
+    rendererType,
+  };
+}

--- a/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
+++ b/frontend/src/features/notes/editor/extensions/file-card/inline-preview/useInlinePreviewContent.ts
@@ -27,8 +27,8 @@ import type { InlineRendererType } from './is-inline-previewable';
 export interface UseInlinePreviewContentResult {
   /** Attach to the card container element to trigger IntersectionObserver. */
   containerRef: RefObject<HTMLDivElement | null>;
-  /** The fetched text content, undefined while loading or on error. */
-  content: string | undefined;
+  /** The fetched content: string for text types, ArrayBuffer for binary Office types. */
+  content: string | ArrayBuffer | undefined;
   /** The signed URL for the artifact (used by the download button). */
   signedUrl: string;
   /** True while signed URL or content fetch is in-flight. */


### PR DESCRIPTION
## Summary
- Upgrade FileCardExtension to render **inline file content previews** within TipTap notes
- **9 file types** now render content directly in notes: code (syntax highlighted), markdown (formatted HTML), CSV (table), JSON (formatted), XLSX (SheetJS), DOCX (docx-preview), PPTX (slide viewer with navigation), HTML (sandboxed iframe), plain text
- Lazy loading via IntersectionObserver — content only fetches when card scrolls into view
- Header bar with action buttons: Copy, Download, Edit in IDE, Expand to modal
- Expand/collapse toggle for long content (first ~30 lines for code, ~10 rows for CSV)
- Non-previewable types (PDF, images, binary) keep existing compact FileCard unchanged

### New files (7)
- `inline-preview/is-inline-previewable.ts` — MIME routing utility
- `inline-preview/FilePreviewConfigContext.ts` — React context for workspace/project IDs
- `inline-preview/useInlinePreviewContent.ts` — IntersectionObserver + signed URL + content hook
- `inline-preview/InlinePreviewHeader.tsx` — 40px header bar with 4 action buttons
- `inline-preview/SkeletonPreviewCard.tsx` — Loading skeleton
- `inline-preview/InlineContentRenderer.tsx` — Dispatches to 9 renderer types (all lazy-loaded)
- `inline-preview/index.ts` — Barrel export

### Modified files (3)
- `FileCardView.tsx` — Upgraded ready state with conditional inline preview rendering
- `notes/[noteId]/page.tsx` — Added FilePreviewConfigContext.Provider
- `issues/[issueId]/page.tsx` — Added FilePreviewConfigContext.Provider

## Test plan
- [ ] Upload `.ts` or `.py` file → verify syntax-highlighted code preview inline
- [ ] Upload `.md` file → verify rendered HTML (headings, lists, bold)
- [ ] Upload `.csv` file → verify table view with headers and rows
- [ ] Upload `.json` file → verify formatted, highlighted JSON
- [ ] Upload `.xlsx` file → verify SheetJS table renders inline
- [ ] Upload `.docx` file → verify formatted document renders inline
- [ ] Upload `.pptx` file → verify slide renders with ← → navigation
- [ ] Upload `.html` file → verify sandboxed iframe renders inline
- [ ] Upload `.txt` file → verify plain text renders inline
- [ ] Upload `.pdf` or `.docx` (legacy .doc) → verify compact card unchanged
- [ ] Scroll file card into view → verify skeleton appears then content loads
- [ ] Test header buttons: Copy, Download, Edit in IDE, Expand to modal
- [ ] Click preview content → verify FilePreviewModal opens
- [ ] Click "Show more" → verify inline expansion, "Show less" collapses
- [ ] Check browser console for no flushSync or React lifecycle errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline file previews in notes and issue pages for markdown, code, JSON, CSV, Excel, Word, PowerPoint, HTML, and text.
  * Preview cards with header actions: copy, download, expand-to-modal, and open-in-editor; keyboard activation supported.
  * Lazy-loading previews with workspace/project-aware signed-URL fetching, intersection-based loading, and improved skeletons/error placeholders.
  * Collapsible/truncation-aware previews with “show more”, slide navigation for presentations, and stable preview-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->